### PR TITLE
bind_null, get_autocommit, column_text

### DIFF
--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -71,7 +71,7 @@ mod aliased {
         sqlite3_value_text as value_text, sqlite3_value_type as value_type,
         sqlite3_vtab_collation as vtab_collation, sqlite3_vtab_config as vtab_config,
         sqlite3_vtab_distinct as vtab_distinct, sqlite3_vtab_nochange as vtab_nochange,
-        sqlite3_vtab_on_conflict as vtab_on_conflict,
+        sqlite3_vtab_on_conflict as vtab_on_conflict, sqlite3_get_autocommit as get_autocommit
     };
 }
 
@@ -583,4 +583,8 @@ pub fn value_pointer(arg1: *mut value, p: *mut c_char) -> *mut c_void {
 
 pub fn vtab_distinct(index_info: *mut index_info) -> c_int {
     unsafe { invoke_sqlite!(vtab_distinct, index_info) }
+}
+
+pub fn get_autocommit(db: *mut sqlite3) -> c_int {
+    unsafe { invoke_sqlite!(get_autocommit, db) }
 }

--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use core::ffi::{c_char, c_int, c_uint, c_void, CStr};
+use core::ffi::{c_char, c_uchar, c_int, c_uint, c_void, CStr};
 use core::ptr;
 
 use alloc::borrow::ToOwned;
@@ -252,6 +252,10 @@ pub fn column_text<'a>(stmt: *mut stmt, c: c_int) -> &'a str {
         let slice = core::slice::from_raw_parts(bytes as *const u8, len as usize);
         core::str::from_utf8_unchecked(slice)
     }
+}
+
+pub fn column_text_ptr(stmt: *mut stmt, c: c_int) -> *const c_uchar {
+    unsafe { invoke_sqlite!(column_text, stmt, c) }
 }
 
 pub fn column_blob(stmt: *mut stmt, c: c_int) -> *const c_void {

--- a/sqlite_nostd/src/nostd.rs
+++ b/sqlite_nostd/src/nostd.rs
@@ -242,6 +242,8 @@ pub trait Connection {
         x_auth: Option<XAuthorizer>,
         user_data: *mut c_void,
     ) -> Result<ResultCode, ResultCode>;
+
+    fn get_autocommit(&self) -> bool;
 }
 
 impl Connection for ManagedConnection {
@@ -327,6 +329,11 @@ impl Connection for ManagedConnection {
     #[inline]
     fn errcode(&self) -> ResultCode {
         self.db.errcode()
+    }
+
+    #[inline]
+    fn get_autocommit(&self) -> bool {
+        self.db.get_autocommit()
     }
 
     #[cfg(all(feature = "static", not(feature = "omit_load_extension")))]
@@ -534,6 +541,10 @@ impl Connection for *mut sqlite3 {
 
     fn errcode(&self) -> ResultCode {
         ResultCode::from_i32(errcode(*self)).unwrap()
+    }
+
+    fn get_autocommit(&self) -> bool {
+        get_autocommit(*self) != 0
     }
 }
 

--- a/sqlite_nostd/src/nostd.rs
+++ b/sqlite_nostd/src/nostd.rs
@@ -604,7 +604,16 @@ impl ManagedStmt {
 
     #[inline]
     pub fn column_text(&self, i: i32) -> Result<&str, ResultCode> {
-        Ok(column_text(self.stmt, i))
+        let len = column_bytes(self.stmt, i);
+        let ptr = column_text_ptr(self.stmt, i);
+        if ptr.is_null() {
+            Err(ResultCode::NULL)
+        } else {
+            Ok(unsafe {
+                let slice = core::slice::from_raw_parts(ptr as *const u8, len as usize);
+                core::str::from_utf8_unchecked(slice)
+            })
+        }
     }
 
     #[inline]

--- a/sqlite_nostd/src/nostd.rs
+++ b/sqlite_nostd/src/nostd.rs
@@ -669,6 +669,14 @@ impl ManagedStmt {
     }
 
     #[inline]
+    pub fn bind_null(&self, i: i32) -> Result<ResultCode, ResultCode> {
+        convert_rc(bind_null(
+            self.stmt,
+            i
+        ))
+    }
+
+    #[inline]
     pub fn clear_bindings(&self) -> Result<ResultCode, ResultCode> {
         convert_rc(clear_bindings(self.stmt))
     }


### PR DESCRIPTION
I started using this for my own SQLite extensions - it's really great to be able to write lightweight extensions in Rust.

I've added some methods I need:
 * bind_null
 * get_autocommit

Additionally, I refactored column_text to handle cases where the column is NULL - same as how column_blob is implemented.
