### PR TITLE
qualify `slice` module with `::core` in `args{_mut}!`

### DIFF
--- a/sqlite3_capi/src/capi.rs
+++ b/sqlite3_capi/src/capi.rs
@@ -111,14 +111,14 @@ pub extern "C" fn droprust(ptr: *mut c_void) {
 #[macro_export]
 macro_rules! args {
     ($argc:expr, $argv:expr) => {
-        unsafe { slice::from_raw_parts($argv, $argc as usize) }
+        unsafe { ::core::slice::from_raw_parts($argv, $argc as usize) }
     };
 }
 
 #[macro_export]
 macro_rules! args_mut {
     ($argc:expr, $argv:expr) => {
-        unsafe { slice::from_raw_parts_mut($argv, $argc as usize) }
+        unsafe { ::core::slice::from_raw_parts_mut($argv, $argc as usize) }
     };
 }
 


### PR DESCRIPTION
the current implementation can create an error at the call site if the `slice` module is not in scope